### PR TITLE
fix environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,6 @@ dependencies:
     - croissant-ml==0.0.3
     - cryptography==35.0.0
     - cycler==0.10.0
-    - evaldb==0.2.0
     - flask==2.0.2
     - flask-sqlalchemy==2.5.1
     - greenlet==1.1.2
@@ -64,7 +63,7 @@ dependencies:
     - networkx==2.6.3
     - numpy==1.21.2
     - opencv-python==4.5.3.56
-    - ophys-etl-pipelines==0.1.dev1703+g57e735d
+    - git+https://github.com/AllenInstitute/ophys_etl_pipelines@ticket/349/classifier/artifacts
     - packaging==21.0
     - pandas==1.3.4
     - pillow==8.4.0


### PR DESCRIPTION
this fixes the problem with installing ophys_etl_pipelines

I just commented out the line where we try to install Dan's eval_db repo. As I said, when I naively tried to do it, GitHub asked me for a username and password. We should probably just make that repository public so that users don't have to jump through that hoop. There might have been an important reason Dan didn't make it public, though.