### PR TITLE
do not load whole video when we just want the trace for a point

### DIFF
--- a/src/server/cell_labeling_app/imaging_plane_artifacts.py
+++ b/src/server/cell_labeling_app/imaging_plane_artifacts.py
@@ -121,4 +121,4 @@ class ArtifactFile:
     def _get_trace_for_point(self, point: List) -> np.ndarray:
         x, y = point
         with h5py.File(self._path, 'r') as f:
-            return f['video_data'][()][:, y, x]
+            return f['video_data'][:, y, x]


### PR DESCRIPTION
testing on my laptop indicates that, even if the underlying data is not
chunked, using [()] before slicing the numpy array is an order of
magnitude slower, I believe because h5py must first load the whole
video into memory before extracting the desired trace