### PR TITLE
Ticket-29: Sample SSF experiments in depth bins

### DIFF
--- a/notebooks/ticket-29.ipynb
+++ b/notebooks/ticket-29.ipynb
@@ -1,0 +1,341 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f9f9e9e3",
+   "metadata": {},
+   "source": [
+    "Sampling for CellApp Training\n",
+    "========================\n",
+    "\n",
+    "Below is a quick bit of code that was used to select a set of experiments and regions for the labeling effort. The charges were to: sample in depth; make sure a representative set of \"problem experiments\" (listed below) make it in the sample; make sure a set of 3P exeriments are also sampled (exeriments starting with 8).\n",
+    "\n",
+    "The sampling chosen was to sample uniformly for each unique value of depth and sample experiments without replacement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1e0b5b24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import json\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3fb7358",
+   "metadata": {},
+   "source": [
+    "Load experiment metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8285b36b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_data = json.load(open('/allen/programs/mindscope/workgroups/surround/'\n",
+    "                           'select_validation/ssf_metadata.json'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "454d4770",
+   "metadata": {},
+   "source": [
+    "Load data for experiment id, depth and experiment type (2P vs 3P) and drop into a DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3425b3df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp_depths = []\n",
+    "for key, data in json_data.items():\n",
+    "    exp_depths.append({'exp_id': int(key), \n",
+    "                       'depth': data['imaging_depth'],\n",
+    "                       'type': 2 if int(key[0]) < 8 else 3})\n",
+    "exp_depths = pd.DataFrame(exp_depths)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e875547",
+   "metadata": {},
+   "source": [
+    "Plot the unique values of depth split by experiment type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8c45da05",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7fde12f76400>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUoAAAE9CAYAAABtDit8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAhq0lEQVR4nO3deXRV9bn/8fdDjJCrQCpktUwSpIgyhAABRa4KuChoEamglVqLU2n706L1XgduV8Xrsqu2Djj1ii5nSyuISHGsVERxABskzKWi0gqiRJCpAibw/P7YO8eQnLBPhp1zCJ/XWmdln+/e+7ufDHzY0/luc3dERKRmzdJdgIhIplNQiohEUFCKiERQUIqIRFBQiohEUFCKiEQ4It0F1Fbbtm09Pz8/3WWISBOzZMmSz909L9m8Qy4o8/PzKS4uTncZItLEmNk/a5qnQ28RkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQix3kdpZuuBncA+oNzdi6rMN+Bu4CzgS+Bid3+vobY/Z+lGbvvLWj7Ztpv2uTlcO6I7Y/p2ULvaD8l2SR+Lc+DeMCiL3P3zGuafBfycIChPAu5295MO1mdRUZGncsP5nKUbmTx7BbvL9iXacrKzGNu/A88s2ah2tR9S7b85t7fCMmZmtqTqzlxiXpqD8gFggbv/KXy/Fhji7ptq6jPVoBx863w2bttdrT3LjH1Jvme1qz2T2zvk5vDWDcOqtUvDOVhQxn2O0oFXzGyJmU1MMr8D8HGl9xvCtgOY2UQzKzaz4tLS0pQ2/EmSkASS/hGqXe2Z3l7T37M0jriD8j/dvR9wJnCFmZ1Wl07c/UF3L3L3ory8pJ9Zr6Z9bk7S9iwztav9kGuv6e9ZGkesQenuG8Ovm4FngYFVFtkIdKr0vmPYVm/XjuhOTnbWAW052VmMP6mT2tV+yLVfO6I7kj6xXfU2s6OAZu6+M5z+DnBzlcXmAlea2VMEF3O2H+z8ZG1UnPhOdvWwqPMxalf7Idcu6RPbxRwzO45gLxKCQP6ju//azH4K4O7TwtuD7gNGEtwedIm7H/RKTaoXc0REauNgF3Ni26N09w+BPknap1WaduCKuGoQEWkI+mSOiEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIhNiD0syyzGypmT2fZN7FZlZqZiXh6/K46xERqa3YHldbyVXAGqBVDfNnuPuVjVCHiEidxLpHaWYdge8CD8W5HRGROMV96H0XcB2w/yDLjDWz5WY2y8w6xVyPiEitxRaUZjYK2OzuSw6y2HNAvrsXAPOAx2voa6KZFZtZcWlpaQzViojULM49ysHAaDNbDzwFDDOzP1RewN23uPve8O1DQP9kHbn7g+5e5O5FeXl5MZYsIlJdbEHp7pPdvaO75wMXAPPd/YeVlzGzdpXejia46CMiklEa46r3AczsZqDY3ecCk8xsNFAObAUubux6RESimLunu4ZaKSoq8uLi4nSXISJNjJktcfeiZPP0yRwRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQixB6WZZZnZUjN7Psm85mY2w8zWmdliM8uPux4RkdpqjD3Kq4A1Ncy7DPjC3b8NTAV+2wj1iIjUSqxBaWYdge8CD9WwyDnA4+H0LOAMM7M4axIRqa249yjvAq4D9tcwvwPwMYC7lwPbgTYx1yQiUiuxBaWZjQI2u/uSBuhropkVm1lxaWlpA1QnIpK6OPcoBwOjzWw98BQwzMz+UGWZjUAnADM7AmgNbKnakbs/6O5F7l6Ul5cXY8kiItXFFpTuPtndO7p7PnABMN/df1hlsbnAhHB6XLiMx1WTiEhdHNHYGzSzm4Fid58LPAw8aWbrgK0EgSoiklEaJSjdfQGwIJy+sVL7HuC8xqhBRKSu9MkcEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEICkoRkQgKShGRCApKEZEIsQWlmbUws3fNbJmZrTKz/02yzMVmVmpmJeHr8rjqERGpqzif670XGObuu8wsG3jTzF5y90VVlpvh7lfGWIeISL3EFpTu7sCu8G12+PK4ticiEpdYz1GaWZaZlQCbgXnuvjjJYmPNbLmZzTKzTnHWIyJSF7EGpbvvc/dCoCMw0Mx6VVnkOSDf3QuAecDjyfoxs4lmVmxmxaWlpXGWLCJSTaNc9Xb3bcBrwMgq7VvcfW/49iGgfw3rP+juRe5elJeXF2utIiJVxXnVO8/McsPpHGA48Pcqy7Sr9HY0sCauekRE6irOq97tgMfNLIsgkGe6+/NmdjNQ7O5zgUlmNhooB7YCF8dYj4hInVhwcfrQUVRU5MXFxekuQ0SaGDNb4u5FyebpkzkiIhEUlCIiERSUIiIRFJQiIhEUlCIiERSUIiIRFJQiIhEUlCIiERSUIiIRFJQiIhEUlCIiERSUIiIRFJQiIhEUlCIiEVIKSjN7NZU2EZGm6KAD95pZC+A/gLZm9g3AwlmtgA4x1yYikhGiRjj/CXA10B5YwtdBuQO4L76yREQyx0GD0t3vBu42s5+7+72NVJOISEZJ6Zk57n6vmZ0C5Fdex92fiKkuEZGMkVJQmtmTQFegBNgXNjugoBSRJi/VpzAWAT38UHsSmYhIA0j1PsqVwLfiLEREJFOlukfZFlhtZu8Ceysa3X10TSuEtxa9ATQPtzPL3adUWaY5weF7f2AL8H13X1+bb0BEJG6pBuVNdeh7LzDM3XeZWTbwppm95O6LKi1zGfCFu3/bzC4Afgt8vw7bEhGJTapXvV+vbcfh+cxd4dvs8FX1HOc5fB3Cs4D7zMx0LlREMkmqH2HcaWY7wtceM9tnZjtSWC/LzEqAzcA8d19cZZEOwMcA7l4ObAfa1Oo7EBGJWap7lC0rps3MCPYET05hvX1AoZnlAs+aWS93X1nbIs1sIjAR4Nhjj63t6iIi9VLr0YM8MAcYUYt1tgGvASOrzNoIdAIwsyOA1gQXdaqu/6C7F7l7UV5eXm1LFhGpl1RvOD+30ttmBPdV7olYJw8oc/dtZpYDDCe4WFPZXGAC8A4wDpiv85MikmlSvep9dqXpcmA9weH3wbQDHjezLIJwnenuz5vZzUCxu88FHgaeNLN1wFbggtoULyLSGFI9R3lJbTt29+VA3yTtN1aa3gOcV9u+RUQaU6pXvTua2bNmtjl8PWNmHeMuTkQkE6R6MedRgvOJ7cPXc2GbiEiTl2pQ5rn7o+5eHr4eA3T5WUQOC6kG5RYz+2F4A3mWmf2QJLfxiIg0RakG5aXA+cCnwCaCW3kujqkmEZGMkurtQTcDE9z9CwAzOwa4nSBARUSatFT3KAsqQhLA3beS5NYfEZGmKNWgbBY+rhZI7FGmujcqInJISzXs7gDeMbOnw/fnAb+OpyQRkcyS6idznjCzYmBY2HSuu6+OrywRkcyR8uFzGIwKRxE57NR6mDURkcONglJEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJEJsQWlmnczsNTNbbWarzOyqJMsMMbPtZlYSvm5M1peISDrFOaZkOfBf7v6embUElpjZvCSjDi1091Ex1iEiUi+x7VG6+yZ3fy+c3gmsATrEtT0Rkbg0yjlKM8sneHTE4iSzB5nZMjN7ycx6NkY9IiK1EfvjHMzsaOAZ4Gp331Fl9ntAZ3ffZWZnAXOAbkn6mAhMBDj22GPjLVhEpIpY9yjNLJsgJKe7++yq8919h7vvCqdfBLLNrG2S5R509yJ3L8rLy4uzZBGRauK86m3Aw8Aad7+zhmW+FS6HmQ0M69kSV00iInUR56H3YOAiYIWZlYRt/wMcC+Du04BxwM/MrBzYDVzg7h5jTSIitRZbULr7m4BFLHMfcF9cNYiINAR9MkdEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJEJsQWlmnczsNTNbbWarzOyqJMuYmd1jZuvMbLmZ9YurHhGRuortud5AOfBf7v6embUElpjZPHdfXWmZM4Fu4esk4P7wq4hIxohtj9LdN7n7e+H0TmAN0KHKYucAT3hgEZBrZu3iqklEpC4a5RylmeUDfYHFVWZ1AD6u9H4D1cNURCStYg9KMzsaeAa42t131LGPiWZWbGbFpaWlDVugiEiEWIPSzLIJQnK6u89OsshGoFOl9x3DtgO4+4PuXuTuRXl5efEUKyJSgzivehvwMLDG3e+sYbG5wI/Cq98nA9vdfVNcNYmI1EWcV70HAxcBK8ysJGz7H+BYAHefBrwInAWsA74ELomxHhGROoktKN39TcAilnHgirhqEBFpCPpkjohIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIBAWliEgEBaWISAQFpYhIhNiC0sweMbPNZrayhvlDzGy7mZWErxvjqkVEpD5ie6438BhwH/DEQZZZ6O6jYqxBRKTeYtujdPc3gK1x9S8i0ljSfY5ykJktM7OXzKxnmmsREUkqzkPvKO8Bnd19l5mdBcwBuiVb0MwmAhMBjj322EYrUEQE0rhH6e473H1XOP0ikG1mbWtY9kF3L3L3ory8vEatU0QkbUFpZt8yMwunB4a1bElXPSIiNYnt0NvM/gQMAdqa2QZgCpAN4O7TgHHAz8ysHNgNXODuHlc9IiJ1FVtQuvv4iPn3Edw+JCKS0dJ5MafBlJWVsWHDBvbs2ZPuUqSOWrRoQceOHcnOzk53KSLVNImg3LBhAy1btiQ/P5/wtKccQtydLVu2sGHDBrp06ZLuckSqSfd9lA1iz549tGnTRiF5iDIz2rRpoyMCyVhNIigBheQhTr8/yWRNJijT6eOPP2bo0KH06NGDnj17cvfddyfmXXzxxXTp0oXCwkL69evHO++8k8ZKA5988gnjxo2LdRvr16/nj3/8Y6zbEGksh2VQzlm6kcG3zqfLDS8w+Nb5zFm6sV79HXHEEdxxxx2sXr2aRYsW8fvf/57Vq1cn5t92222UlJRw66238pOf/KS+5ddLeXk57du3Z9asWbFuR0EpTclhF5Rzlm5k8uwVbNy2Gwc2btvN5Nkr6hWW7dq1o1+/fgC0bNmSE088kY0bq/d32mmnsW7dumrtpaWljB07lgEDBjBgwADeeustAM455xyeeCIYfOmBBx7gwgsvBGDIkCFcddVVFBYW0qtXL959910A/v3vf3PppZcycOBA+vbty5///GcAHnvsMUaPHs2wYcM444wzWL9+Pb169UrMGzNmDMOHDyc/P5/77ruPO++8k759+3LyySezdWswrskHH3zAyJEj6d+/P6eeeip///vfgWCPedKkSZxyyikcd9xxiQC+4YYbWLhwIYWFhUydOpVVq1YxcOBACgsLKSgo4P3336/zz1uk0bn7IfXq37+/V7V69epqbTU55Teveufrn6/2OuU3r6bcx8F89NFH3qlTJ9++fbu7u0+YMMGffvppd3efOXOmDxw4sNo648eP94ULF7q7+z//+U8/4YQT3N39008/9a5du/obb7zh3bp18y1btri7++mnn+6XX365u7u//vrr3rNnT3d3nzx5sj/55JPu7v7FF194t27dfNeuXf7oo496hw4dEut/9NFHiXUeffRR79q1q+/YscM3b97srVq18vvvv9/d3a+++mqfOnWqu7sPGzbM//GPf7i7+6JFi3zo0KGJ72/cuHG+b98+X7VqlXft2tXd3V977TX/7ne/m/ger7zySv/DH/7g7u579+71L7/8strPoTa/R5GGBhR7DbnTJG4Pqo1Ptu2uVXtt7Nq1i7Fjx3LXXXfRqlWrRPu1117LLbfcQl5eHg8//HC19f76178ecKi+Y8cOdu3axTe/+U1uvvlmhg4dyrPPPssxxxyTWGb8+OB+/tNOO40dO3awbds2XnnlFebOncvtt98OBHcD/Otf/wJg+PDhB6xf2dChQ2nZsiUtW7akdevWnH322QD07t2b5cuXs2vXLt5++23OO++8xDp79+5NTI8ZM4ZmzZrRo0cPPvvss6TbGDRoEL/+9a/ZsGED5557Lt26JR3/RCQjHXZB2T43h41JQrF9bk69+i0rK2Ps2LFceOGFnHvuuQfMu+222w568WT//v0sWrSIFi1aVJu3YsUK2rRpwyeffHJAe9WrxGaGu/PMM8/QvXv3A+YtXryYo446qsbtN2/ePDHdrFmzxPtmzZpRXl7O/v37yc3NpaSkJHJ9r+FTqD/4wQ846aSTeOGFFzjrrLN44IEHGDZsWI01iWSSw+4c5bUjupOTnXVAW052FteO6F7DGtHcncsuu4wTTzyRa665ptbrf+c73+Hee+9NvK8IpHfffZeXXnqJpUuXcvvtt/PRRx8llpkxYwYAb775Jq1bt6Z169aMGDGCe++9NxFWS5curfP3VFmrVq3o0qULTz/9NBB8v8uWLTvoOi1btmTnzp2J9x9++CHHHXcckyZN4pxzzmH58uUNUptIYzjsgnJM3w785tzedMjNwYAOuTn85tzejOnboc59vvXWWzz55JPMnz+fwsJCCgsLefHFF1Ne/5577qG4uJiCggJ69OjBtGnT2Lt3Lz/+8Y955JFHaN++PXfccQeXXnppIgRbtGhB3759+elPf5o4nP/Vr35FWVkZBQUF9OzZk1/96ld1/p6qmj59Og8//DB9+vShZ8+eiQtFNSkoKCArK4s+ffowdepUZs6cSa9evSgsLGTlypX86Ec/arDaROJmNR0qZaqioiIvLi4+oG3NmjWceOKJaaqo8Q0ZMoTbb7+doqKidJfSoA6336NkFjNb4u5J/1EddnuUIiK1ddhdzGkKFixYkO4SRA4r2qMUEYmgoBQRiaCgFBGJoKAUEYmgoGwAe/bsYeDAgYl7DKdMmZKYN2TIELp3706fPn0YPHgwa9euTWOlgeLiYiZNmhTrNkpKSmp1L6lIJjs8g3L5TJjaC27KDb4un1mv7po3b878+fNZtmwZJSUlvPzyyyxatCgxf/r06SxbtowJEyZw7bXX1rP4+ikvL6eoqIh77rkn1u0oKKUpOfyCcvlMeG4SbP8Y8ODrc5PqFZZmxtFHHw0En/kuKytLOmJ3TcOsJRvCrLy8nAEDBiRuBZo8eTK//OUvAcjPz+e6666jd+/eDBw4MNFnTcO13XTTTVx00UUMHjyYiy66iAULFjBq1KjEvAkTJnDqqafSuXNnZs+eneh75MiRlJWVAbBkyRJOP/10+vfvz4gRI9i0aRMQ7DFff/31DBw4kOOPP56FCxfy1VdfceONNzJjxgwKCwuZMWMGr7/+euJTS3379j3g440iGa+mYYXq+wIeATYDK2uYb8A9wDpgOdAvlX7rO8ya39nTfUqr6q87e6beRxLl5eXep08fP+qoo/y6665LtJ9++un+t7/9zd3df/e73/n5559fbd2ahjBbuXKln3DCCT5v3jwvLCz0vXv3urt7586d/ZZbbnF398cffzwxnFlNw7VNmTLF+/XrlxjarPIQaFOmTPHBgwf7V1995SUlJZ6Tk+Mvvviiu7uPGTPGn332Wf/qq6980KBBvnnzZnd3f+qpp/ySSy5JfH/XXHONu7u/8MILfsYZZ7h7MHzbFVdckfgeR40a5W+++aa7u+/cudPLysqq/RwOy2HWls0I/yZbB1+XzajbMpnaV6bWngRpGmbtMYLndj9Rw/wzgW7h6yTg/vBrvLZvqF17irKysigpKWHbtm1873vfY+XKlYnBcS+88EJycnLIz88/YPAL4KBDmPXs2ZOLLrqIUaNG8c4773DkkUcmlqkYZm38+PH84he/AGoerg1g9OjR5OQkHyHpzDPPJDs7m969e7Nv3z5GjhwJBMOsrV+/nrVr17Jy5UqGDx8OwL59+2jXrl1i/YrRkvr378/69euTbmPw4MFcc801idGVOnbseLAf5+Gh4uimLBzNquLoBqDg/NSXydS+MrX2Oojt0Nvd3wC2HmSRc4AnwjBfBOSaWbuDLN8wWtfwD7Sm9lrKzc1l6NChvPzyy4m26dOnU1JSwpw5c+jUqdMBy1cewqzitWbNmsT8FStWkJuby+bNmw9Yr/KhfcV0xXBtFf1s3LgxcUoglWHWmjVrRnZ2dqK/imHW3J2ePXsm+l2xYgWvvPJKtfWzsrIoLy9Puo0bbriBhx56iN27dzN48ODECOmHtVdv/vofdIWy3UF7bZbJ1L4ytfY6SOc5yg7Ax5XebwjbqjGziWZWbGbFpaWl9dvqGTdCdpU9q+ycoL2OSktL2bZtGwC7d+9m3rx5nHDCCSmte7AhzGbPns3WrVt54403+PnPf57YBnw9zNqMGTMYNGgQUPNwbfXVvXt3SktLEw9GKysrY9WqVQddp+owax988AG9e/fm+uuvZ8CAAQpKSO3oJtUjoEzsK1Nrr4ND4mKOuz/o7kXuXpSXl1e/zgrOh7PvgdadAAu+nn1PvXbLN23axNChQykoKGDAgAEMHz48cbEkFcmGMPv8888Te2HHH388V155JVdddVVinS+++IKCggLuvvtupk6dCiQfrq0hHHnkkcyaNYvrr7+ePn36UFhYyNtvv33QdYYOHcrq1asTF3PuuusuevXqRUFBAdnZ2Zx55pkNUtshLZWjm1SPgDKxr0ytvQ5iHWbNzPKB5929V5J5DwAL3P1P4fu1wBB333SwPjXMWnDVu7i4mLZt26a7lAZ1uP0eq51Pg+DopvJ/3Kksk6l9ZWrtNcjUYdbmAj+ywMnA9qiQFGlSUjm6SfUIKBP7ytTa6yC2PUoz+xMwBGgLfAZMAbIB3H2aBVcM7gNGAl8Cl7h7cfLevqY9yqZLv0dJp4PtUcZ2e5C7j4+Y78AVcW1fRKShHBIXc1IR57lWiZ9+f5LJmkRQtmjRgi1btugf2yHK3dmyZUvSx/WKZIIm8SiIjh07smHDBup9j6WkTYsWLfRpHclYTSIos7Oz6dKlS7rLEJEmqkkceouIxElBKSISQUEpIhIh1o8wxsHMSoF/prGEtsDnadx+MplYE2RmXZlYE6iu2oirps7unnQwiUMuKNPNzIpruns/XTKxJsjMujKxJlBdtZGOmnToLSISQUEpIhJBQVl7D6a7gCQysSbIzLoysSZQXbXR6DXpHKWISATtUYqIRFBQVmJmj5jZZjNbWantGDObZ2bvh1+/Ebabmd1jZuvMbLmZ9Yuxrk5m9pqZrTazVWZ2VbprM7MWZvaumS0La/rfsL2LmS0Otz3DzI4M25uH79eF8/MbuqZKtWWZ2VIzez6DalpvZivMrMTMisO2TPjbyjWzWWb2dzNbY2aD0vx31T38GVW8dpjZ1Wn/WdX0HNvD8QWcBvSj0rPIgd8BN4TTNwC/DafPAl4ieD75ycDiGOtqR/jcc6Al8A+gRzprC/s+OpzOBhaH25oJXBC2TwN+Fk7/P2BaOH0BMCPGn9c1wB8JHkNChtS0HmhbpS0T/rYeBy4Pp48EcjOhrnB7WcCnQOd01xTbN3movoD8KkG5FmgXTrcD1obTDwDjky3XCDX+GRieKbUB/wG8R/Bc9s+BI8L2QcBfwum/AIPC6SPC5SyGWjoCrwLDgOfDf0BprSnsP1lQpvX3B7QGPqr6Pae7rkr9fwd4KxNq0qF3tG/618/y+RT4Zjid8uN2G1J4eNiXYA8urbWFh7glwGZgHvABsM3dKx7uXXm7iZrC+duBNg1dE3AXcB2wP3zfJgNqAnDgFTNbYmYTw7Z0/211AUqBR8NTFQ+Z2VEZUFeFC4A/hdNprUlBWQse/JeVttsEzOxo4BnganffUXleOmpz933uXkiwFzcQSO1h5jExs1HAZndfks46avCf7t4POBO4wsxOqzwzTX9bRxCcarrf3fsC/yY4rE13XYTnkUcDT1edl46aFJTRPjOzdgDh181h+0agU6XlOoZtsTCzbIKQnO7uszOpNnffBrxGcFiba2YV45xW3m6ipnB+a2BLA5cyGBhtZuuBpwgOv+9Oc00AuPvG8Otm4FmC/1jS/fvbAGxw98Xh+1kEwZnuuiD4D+U9d/8sfJ/WmhSU0eYCE8LpCQTnByvaG+Vxu2ZmwMPAGne/MxNqM7M8M8sNp3MIzpmuIQjMcTXUVFHrOGB+uGfQYNx9srt3dPd8gsO2+e5+YTprAjCzo8ysZcU0wbm3laT5b8vdPwU+NrPuYdMZwOp01xUaz9eH3RXbTl9NcZ2IPRRf4S9mE1BG8L/tZQTnrF4F3gf+ChwTLmvA7wnOy60AimKs6z8JDjWWAyXh66x01gYUAEvDmlYCN4btxwHvAusIDpuah+0twvfrwvnHxfy7HMLXV73TWlO4/WXhaxXwy7A9E/62CoHi8Pc4B/hGuusCjiLYs29dqS2tNemTOSIiEXToLSISQUEpIhJBQSkiEkFBKSISQUEpIhJBQSlpZWY3mdl/13HdQjM7q7Z9mdm+cGSa9nXZbpL+XjOzXWaWUc+WkYajoJRDWSHB/aS1tdvdC939k4Yowt2HEtyLKE2UglIanZn90sz+YWZvAt0rtXc1s5fDgSMWmtkJYftjZjbNzIrD9UaFnwW+Gfh+uHf4/bCbHma2wMw+NLNJKdazq9L0ODN7rNJ27zezRWF/QywYs3RNxTJyeDgiehGRhmNm/Qk+XlhI8Pf3HlAxiMWDwE/d/X0zOwn4P4LPa0Mw/N1AoCvBRxK/DdxI8EmMK8O+byIYmGMowbida83sfncvq0fJ3yD4DPtogo/LDQYuB/5mZoXuXlKPvuUQoaCUxnYq8Ky7fwlgZnPDr0cDpwBPBx9tB6B5pfVmuvt+4H0z+5CaRyp6wd33AnvNbDPBcFwb6lHvc+7uZrYC+MzdV4T1riII75J69C2HCAWlZIpmBONGFtYwv+pnbWv67O3eStP7SO1vvHJfLWrob3+Vvven2Lc0ATpHKY3tDWCMmeWEI+qcDeDB+Jofmdl5kHgWSp9K651nZs3MrCvBIBNrgZ0Eh9j19ZmZnWhmzYDvNUB/0sQoKKVRuft7wAyCkXReAv5WafaFwGVmVjHKzjmV5v2LYISflwjOY+4hOFfZo8rFnLq4geCxEW8TjB4lcgCNHiQZL7zC/Ly7z2qg/na5+9EN0VelPhcA/+3uuk2oCdIepRyOdjT0DecEpwPqc3VdMpj2KEVEImiPUkQkgoJSRCSCglJEJIKCUkQkgoJSRCSCglJEJML/B+TNEuKw6SDzAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 360x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "unique_depth_2p, count_2p = np.unique(\n",
+    "    exp_depths[exp_depths['type'] == 2]['depth'].to_numpy(), return_counts=True)\n",
+    "unique_depth_3p, count_3p = np.unique(\n",
+    "    exp_depths[exp_depths['type'] == 3]['depth'].to_numpy(), return_counts=True)\n",
+    "plt.figure(figsize=(5, 5))\n",
+    "plt.xlabel(\"depth [um]\")\n",
+    "plt.ylabel(\"count\")\n",
+    "plt.plot(unique_depth_2p, count_2p, 'o', label='2P experiments')\n",
+    "plt.plot(unique_depth_3p, count_3p, 'o', label='3P experiments')\n",
+    "plt.legend(loc=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c1a1003",
+   "metadata": {},
+   "source": [
+    "Find the unique values of depth across experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3d53449f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unique_depths = np.unique(exp_depths['depth'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "316090f9",
+   "metadata": {},
+   "source": [
+    "Randomly sub sample experiements without replacement from each unique depth with equal probablity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2d92bec5",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Seed with the first experiment's id.\n",
+    "rng = np.random.default_rng(exp_depths['exp_id'][0])\n",
+    "# List to store selected experiments.\n",
+    "selected_exp_ids = []\n",
+    "n_samples = 80\n",
+    "while len(selected_exp_ids) < n_samples:\n",
+    "    # Randomly select a unique depth.\n",
+    "    depth_bin = unique_depths[rng.integers(0, len(unique_depths))]\n",
+    "    # Find all experiments that have this unique depth.\n",
+    "    sub_exp_ids = exp_depths['exp_id'][exp_depths['depth'] == depth_bin].to_numpy()\n",
+    "    # Randomly grab an experiment id from the list of ids with this depth.\n",
+    "    exp_id = sub_exp_ids[rng.integers(0, len(sub_exp_ids))]\n",
+    "    # If we have already selected this experiment, discard this draw and continue.\n",
+    "    if exp_id in selected_exp_ids:\n",
+    "        continue\n",
+    "    # Append the selected id.\n",
+    "    selected_exp_ids.append(exp_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6fb4da67",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([774392903, 774392931, 774392958, 774393041, 783605202, 783605213,\n",
+       "       783605225, 783605236, 783605259, 783623253, 783623286, 784370396,\n",
+       "       784370407, 784370431, 784388288, 784388321, 784388343, 785569423,\n",
+       "       785569436, 785569447, 785569459, 786334337, 786334350, 786334394,\n",
+       "       786400863, 786400874, 786400885, 787473465, 787473478, 787473500,\n",
+       "       787473512, 788422836, 788422870, 790118127, 790122271, 790122293,\n",
+       "       790122304, 790623924, 790623944, 790624009, 790624031, 790986879,\n",
+       "       790986890, 791920168, 791920202, 792757238, 792757272, 792757295,\n",
+       "       792765535, 792765546, 792765582, 793618831, 793618875, 794123773,\n",
+       "       794123785, 794288307, 794288320, 794288331, 794288342, 794288353,\n",
+       "       794298187, 794298198, 794298220, 795011974, 795012030, 795018546,\n",
+       "       795018557, 795018579, 795897800, 795901861, 795901873, 803616717,\n",
+       "       803958257, 803959659, 803965468, 806844147, 806847865, 806854201,\n",
+       "       806856553, 806928824])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.sort(selected_exp_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6338fcd1",
+   "metadata": {},
+   "source": [
+    "Check to see how many of the problematic experiments there are in this sample. There are 10 so in the full sample the fraction is 0.0625."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1827284f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.075"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "problematic_exp_ids = [774393041, 783605247, 783605259, 784388321, 784388332,\n",
+    "                       784388343, 785569470, 794298198, 794298209, 794298220]\n",
+    "np.isin(problematic_exp_ids, selected_exp_ids).sum() / n_samples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ec2487a",
+   "metadata": {},
+   "source": [
+    "Check to see how many of the 3P experiments there are in this sample. There are 10 so in the full sample the fraction is 0.0625."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5598769e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.1125"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.isin(exp_depths['exp_id'][exp_depths['type'] == 3].to_numpy(),\n",
+    "        selected_exp_ids).sum() / n_samples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6859fb1c",
+   "metadata": {},
+   "source": [
+    "Randomly pick a set of regions for each experiment. Create a dictionary to write to json."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "344dad0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_dict = {}\n",
+    "rng = np.random.default_rng(1234)\n",
+    "for exp_id in selected_exp_ids:\n",
+    "    output_dict[int(exp_id)] = {\"regions\": np.sort(rng.permutation(np.arange(0, 9))[:3]).tolist()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f54a2a4",
+   "metadata": {},
+   "source": [
+    "Write experiment id, region samples to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "66da5a84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('/allen/aibs/informatics/chris.morrison/ticket-29/cell_app_sample.json', 'w') as jfile:\n",
+    "    json.dump(output_dict, jfile, indent=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73115f08",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Not meant to be merged. Adds a notebook preserving the code I used to produce the random sampling of experiments and regions for the labeling effort.