### PR TITLE
Fixes/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,6 @@ Then install the labeling app with
 python setup.py install
 ```
 
-You will need a config file (.py) to run the app. It currently requires the following:
-
-| variable                | description                                                       |
-|-------------------------|-------------------------------------------------------------------|
-| SQLALCHEMY_DATABASE_URI | Path to app database (will get created if does not already exist) |
-| ARTIFACT_DIR            | Path to artifacts (videos, projections, etc) (as hdf5 files)      |
-| LOG_FILE         | Path to log file  |
-| PREDICTIONS_DIR         | Path to classifier predictions pre-labeling   |
-| PORT         | Port to run the app on   |
-| DEBUG         | Whether to enable debug mode (extra logging, etc)  |
-
 If you have not already created and populated your `SQLALCHEMY_DATABASE`, execute `python src/server/database/populate_labeling_job.py` to populate your database of labeling jobs.
 
 Execute `python src/server/main.py` to start the web server.

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -290,6 +290,8 @@ class CellLabelingApp {
             $('button#projection_contrast_reset').attr('disabled', false);
             $('input#projection_contrast_low_quantile').attr('disabled', false);
             $('input#projection_contrast_high_quantile').attr('disabled', false);
+            $('#region_meta').html(
+                `Experiment id: ${this.experiment_id} | Region id: ${this.region['id']}`)
 
             await this.updateShapesOnProjection();
 

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -460,6 +460,28 @@ class CellLabelingApp {
         // Initialize contrast controls
         const contrast = this.#getContrastValues();
         this.#updateContrastControls(contrast);
+
+        // Update labeler stats
+        fetch(
+            `http://localhost:${PORT}/get_label_stats`
+        )
+            .then(data => data.json())
+            .then(stats => {
+                const total = stats['n_total'];
+                const completed = stats['n_completed'];
+                const userLabeled = stats['n_user_has_labeled'];
+                $('p#label_stats').html(
+                    `<p>
+                        You have labeled
+                        <span>${userLabeled}</span> ${userLabeled.length > 1 ? 'regions' : 'region'}
+                        and there are <span>${total - userLabeled - completed}</span> remaining
+                    </p>
+
+                    <p>The labeling job is <span>${Math.round(completed / total * 100)}%</span> complete</p>`
+                );
+            }
+        );
+
     }
 
     async loadNewRegion() {

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -290,8 +290,6 @@ class CellLabelingApp {
             $('button#projection_contrast_reset').attr('disabled', false);
             $('input#projection_contrast_low_quantile').attr('disabled', false);
             $('input#projection_contrast_high_quantile').attr('disabled', false);
-            $('#region_meta').html(
-                `Experiment id: ${this.experiment_id} | Region id: ${this.region['id']}`)
 
             await this.updateShapesOnProjection();
 
@@ -469,6 +467,8 @@ class CellLabelingApp {
         const region = await this.getRandomRegionFromRandomExperiment()
             .then(region => {
                 this.is_loading_new_region = false;
+                $('#region_meta').html(
+                    `Experiment id: ${this.experiment_id} | Region id: ${this.region['id']}`);
                 return region;
             })
             .catch(() => {

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -470,15 +470,19 @@ class CellLabelingApp {
                 const total = stats['n_total'];
                 const completed = stats['n_completed'];
                 const userLabeled = stats['n_user_has_labeled'];
-                $('p#label_stats').html(
-                    `<p>
+                const numLabelersReqPerRegion = stats['num_labelers_required_per_region'];
+                let html = `
+                    <p>
                         You have labeled
                         <span>${userLabeled}</span> ${userLabeled.length > 1 ? 'regions' : 'region'}
                         and there are <span>${total - userLabeled - completed}</span> remaining
-                    </p>
-
-                    <p>The labeling job is <span>${Math.round(completed / total * 100)}%</span> complete</p>`
-                );
+                    </p>`;
+                if (numLabelersReqPerRegion !== null) {
+                    html += `
+                        <p><span>${Math.round(completed / total * 100)}%</span> of regions have been labeled by ${numLabelersReqPerRegion} people</p>
+                    `;
+                }
+                $('p#label_stats').html(html);
             }
         );
 

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -885,21 +885,21 @@ class CellLabelingApp {
                 if (side === 'right_side') {
                     offset = field_of_view_dims[0] - offset;
                 }
-                y0 = offset;
-                x0 = 0;
+                x0 = offset;
+                y0 = 0;
 
-                x1 = field_of_view_dims[1];
-                y1 = offset;
+                y1 = field_of_view_dims[1];
+                x1 = offset;
             } else {
                 let offset = mb[side];
                 if (side === 'bottom') {
                     offset = field_of_view_dims[1] - offset;
                 }
-                y0 = 0;
-                x0 = offset;
+                x0 = 0;
+                y0 = offset;
 
-                y1 = field_of_view_dims[0];
-                x1 = offset;
+                x1 = field_of_view_dims[0];
+                y1 = offset;
             }
 
             return {

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -859,9 +859,9 @@ class CellLabelingApp {
                 color: 'rgb(255, 255, 255)'
             },
             y0: this.region.x,
-            y1: this.region.x + this.region.width,
+            y1: this.region.x + this.region.height,
             x0: this.region.y,
-            x1: this.region.y + this.region.height
+            x1: this.region.y + this.region.width
         }
     }
 

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -549,7 +549,7 @@ class CellLabelingApp {
         const contrast = this.#getContrastValues(low, high);
         const projection_type = $('#projection_type').children("option:selected").val();
         Cookies.set('contrast', JSON.stringify({
-                ...JSON.parse(Cookies.get('contrast')),
+                ...JSON.parse(Cookies.get('contrast') ? Cookies.get('contrast') : null),
                 [projection_type]: contrast
         }));
 

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -885,21 +885,21 @@ class CellLabelingApp {
                 if (side === 'right_side') {
                     offset = field_of_view_dims[0] - offset;
                 }
-                x0 = offset;
-                y0 = 0;
+                y0 = offset;
+                x0 = 0;
 
-                y1 = field_of_view_dims[1];
-                x1 = offset;
+                x1 = field_of_view_dims[1];
+                y1 = offset;
             } else {
                 let offset = mb[side];
                 if (side === 'bottom') {
                     offset = field_of_view_dims[1] - offset;
                 }
-                x0 = 0;
-                y0 = offset;
+                y0 = 0;
+                x0 = offset;
 
-                x1 = field_of_view_dims[0];
-                y1 = offset;
+                y1 = field_of_view_dims[0];
+                x1 = offset;
             }
 
             return {

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -43,4 +43,7 @@
     height: 80px;
     display: none;
 }
-  
+
+p#label_stats span {
+    font-weight: bold;
+}

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -49,6 +49,9 @@
           </div>
         <div class="container app_container" id="app-container">
             <div class="row">
+                <p id="region_meta" style="margin-top: 20px"></p>
+            </div>
+            <div class="row">
                 <div class="col">
                     <div id="projection_container">
                         <div style="width: 572px; height: 572px">

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -49,6 +49,10 @@
             </div>
           </div>
         <div class="container app_container" id="app-container">
+            <div class="row" style="margin-top: 20px">
+                <p id="label_stats">
+                </p>
+            </div>
             <div class="row">
                 <p id="region_meta" style="margin-top: 20px"></p>
             </div>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -19,6 +19,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/9.5.1/math.min.js" integrity="sha512-7+fUzDKxopLeVKiXTdoQQZBl6Zh9Bbl/NrZoowiddStpj7GXTUCM+LOPay4Wzxz14HazsoSsO96UFvvZqAH5rw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
         <script id="MathJax-script" async
             src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
         <script>
             const PORT = "{{ port }}";
         </script>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -93,12 +93,12 @@
                                     <div class="form-group">
                                         <input type="range" id="projection_contrast_low_quantile" name="projection_contrast_low_quantile"
                                             min="0" max="0.5" value="0.0" step=".1" style="margin-top: 20px">
-                                        <label for="projection_contrast_low_quantile" id="projection_contrast_low_quantile_label" style="margin-left: 10px">Low quantile: 0.0</label>
+                                        <label for="projection_contrast_low_quantile" id="projection_contrast_low_quantile_label" style="margin-left: 10px"></label>
                                     </div>
                                     <div class="form-group">
                                         <input type="range" id="projection_contrast_high_quantile" name="projection_contrast_high_quantile"
                                             min="0.8" max="1" value="1.0" step=".01" style="margin-top: 20px">
-                                        <label for="projection_contrast_high_quantile" id="projection_contrast_high_quantile_label" style="margin-left: 10px">High quantile: 1.0</label>
+                                        <label for="projection_contrast_high_quantile" id="projection_contrast_high_quantile_label" style="margin-left: 10px"></label>
                                     </div>
                                     <button class="btn btn-light" id="projection_contrast_reset" style="margin-top: 10px">
                                         Reset

--- a/src/server/cell_labeling_app/backup_manager.py
+++ b/src/server/cell_labeling_app/backup_manager.py
@@ -53,7 +53,7 @@ class BackupManager:
                 time.sleep(self._frequency)
 
     def _make_backup(self):
-        backup_path = self._backup_dir / f'{self._database_path.name}_' / \
+        backup_path = self._backup_dir / f'{self._database_path.name}_' \
                       f'{int(time.time())}.db'
         shutil.copy(self._database_path, backup_path)
 

--- a/src/server/cell_labeling_app/backup_manager.py
+++ b/src/server/cell_labeling_app/backup_manager.py
@@ -1,0 +1,69 @@
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+
+import flask
+from cell_labeling_app.database.database import db
+from cell_labeling_app.database.schemas import UserLabels
+
+logger = logging.getLogger(__name__)
+
+
+class BackupManager:
+    """Backup manager"""
+    def __init__(self,
+                 app: flask.Flask,
+                 database_path: Path,
+                 backup_dir: Path,
+                 frequency: int = 60 * 5):
+        """
+        :param app
+            The flask app, in order to query db
+        :param database_path
+            Path to sqlite database
+        :param backup_dir:
+            Where to write backups
+        :param frequency:
+            Frequency in seconds to check if a backup should be made
+        """
+        self._app = app
+        self._database_path = database_path
+        self._backup_dir = backup_dir
+        self._frequency = frequency
+        with self._app.app_context():
+            self._num_records = self._get_num_label_records()
+        os.makedirs(backup_dir, exist_ok=True)
+
+    def run(self):
+        """Checks to see if there have been new labels added since last time.
+        If so, deletes previous backup and writes new one.
+        Checks if self._frequency seconds"""
+        with self._app.app_context():
+            while True:
+                num_records = self._get_num_label_records()
+                logger.info(f'Current number of label records: {num_records}, '
+                            f'previous: {self._num_records}. '
+                            f'Creating new backup')
+                if num_records > self._num_records:
+                    self._cleanup_backups()
+                    self._make_backup()
+                    self._num_records = num_records
+                time.sleep(self._frequency)
+
+    def _make_backup(self):
+        backup_path = self._backup_dir / f'{self._database_path.name}_' / \
+                      f'{int(time.time())}.db'
+        shutil.copy(self._database_path, backup_path)
+
+    def _cleanup_backups(self):
+        for file in os.listdir(self._backup_dir):
+            os.remove(self._backup_dir / file)
+
+    @staticmethod
+    def _get_num_label_records():
+        num_records = db.session.query(
+            UserLabels
+        ).count()
+        return num_records

--- a/src/server/cell_labeling_app/backup_manager.py
+++ b/src/server/cell_labeling_app/backup_manager.py
@@ -43,9 +43,10 @@ class BackupManager:
         with self._app.app_context():
             while True:
                 num_records = self._get_num_label_records()
-                logger.info(f'Current number of label records: {num_records}, '
-                            f'previous: {self._num_records}.')
                 if num_records > self._num_records:
+                    logger.info(
+                        f'Current number of label records: {num_records}, '
+                        f'previous: {self._num_records}.')
                     self._cleanup_backups()
                     self._make_backup()
                     self._num_records = num_records

--- a/src/server/cell_labeling_app/backup_manager.py
+++ b/src/server/cell_labeling_app/backup_manager.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 import flask
+import numpy as np
 from cell_labeling_app.database.database import db
 from cell_labeling_app.database.schemas import UserLabels
 
@@ -39,7 +40,7 @@ class BackupManager:
     def run(self):
         """Checks to see if there have been new labels added since last time.
         If so, deletes previous backup and writes new one.
-        Checks if self._frequency seconds"""
+        Checks every self._frequency seconds"""
         with self._app.app_context():
             while True:
                 num_records = self._get_num_label_records()
@@ -47,8 +48,8 @@ class BackupManager:
                     logger.info(
                         f'Current number of label records: {num_records}, '
                         f'previous: {self._num_records}.')
-                    self._cleanup_backups()
                     self._make_backup()
+                    self._cleanup_backups()
                     self._num_records = num_records
                 time.sleep(self._frequency)
 
@@ -58,9 +59,21 @@ class BackupManager:
         shutil.copy(self._database_path, backup_path)
         logger.info(f'Created new backup {backup_path}')
 
-    def _cleanup_backups(self):
-        for file in os.listdir(self._backup_dir):
-            os.remove(self._backup_dir / file)
+    def _cleanup_backups(self, retention_count: int = 1):
+        """
+        Deletes old backups
+
+        :param retention_count:
+            The number of backups to retain
+        :return:
+            None, deletes files inplace
+        """
+        backups = os.listdir(self._backup_dir)
+        mod_times = [os.path.getmtime(self._backup_dir / file)
+                     for file in backups]
+        backups_idx_by_time = np.argsort(mod_times)
+        for idx in backups_idx_by_time[:-retention_count]:
+            os.remove(self._backup_dir / backups[idx])
 
     @staticmethod
     def _get_num_label_records():

--- a/src/server/cell_labeling_app/backup_manager.py
+++ b/src/server/cell_labeling_app/backup_manager.py
@@ -44,8 +44,7 @@ class BackupManager:
             while True:
                 num_records = self._get_num_label_records()
                 logger.info(f'Current number of label records: {num_records}, '
-                            f'previous: {self._num_records}. '
-                            f'Creating new backup')
+                            f'previous: {self._num_records}.')
                 if num_records > self._num_records:
                     self._cleanup_backups()
                     self._make_backup()
@@ -53,9 +52,10 @@ class BackupManager:
                 time.sleep(self._frequency)
 
     def _make_backup(self):
-        backup_path = self._backup_dir / f'{self._database_path.name}_' \
+        backup_path = self._backup_dir / f'{self._database_path.stem}_' \
                       f'{int(time.time())}.db'
         shutil.copy(self._database_path, backup_path)
+        logger.info(f'Created new backup {backup_path}')
 
     def _cleanup_backups(self):
         for file in os.listdir(self._backup_dir):

--- a/src/server/cell_labeling_app/config/config.py
+++ b/src/server/cell_labeling_app/config/config.py
@@ -1,9 +1,0 @@
-import uuid
-
-ARTIFACT_DB_PATH = "/allen/aibs/informatics/segmentation_eval_dbs" \
-                   "/ssf_mouse_id_409828.db"
-SQLALCHEMY_DATABASE_URI = 'sqlite:////allen/aibs/informatics/aamster' \
-                          '/cell_labeling_app.db'
-SQLALCHEMY_TRACK_MODIFICATIONS = False
-ARTIFACT_DIR = '/allen/aibs/informatics/danielsf/classifier_prototype_data'
-SESSION_SECRET_KEY = str(uuid.uuid4())

--- a/src/server/cell_labeling_app/database/populate_labeling_job.py
+++ b/src/server/cell_labeling_app/database/populate_labeling_job.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import List, Union
 
 import numpy as np
+import pandas as pd
 from cell_labeling_app.imaging_plane_artifacts import ArtifactFile
 from flask import Flask
 from sqlalchemy import desc
@@ -27,9 +28,9 @@ class Region:
                  experiment_id: str):
         """
         :param x:
-            Region upper left x value in fov coordinates
+            Region upper left row value in array coordinates
         :param y:
-            Region upper left y value in fov coordinates
+            Region upper left col value in array coordinates
         :param width
             Region width
         :param height
@@ -65,20 +66,36 @@ class Region:
 
 
 class RegionSampler:
-    """A class to sample regions from a field of view"""
+    """A class to sample regions from a field of view.
+
+    Can be either sample experiments from LIMS or a file containing a list of
+    pre-selected experiments.
+    """
     def __init__(
         self,
         artifact_path: Union[str, Path],
-        num_regions: int,
-        fov_divisor=4,
-        seed=None
+        num_experiments: int = None,
+        db_url: str = None,
+        selected_experiments_path: str = None,
+        num_regions_per_exp: int = 3,
+        fov_divisor: int = 4,
+        seed: int = None,
     ):
         """
         :param artifact_path
             Path to all possible labeling artifacts, containing imaging plane
             data and metadata
-        :param num_regions:
-            Number of regions to sample
+        :param num_experiments:
+            Number of experiments to sample. Not used if selected_experiments
+            is specified.
+        :param db_url:
+            Sqlalchemy database URL connection to LIMS. Not used if
+            selected_experiments is specified.
+        :param selected_experiments:
+            Path specifying the location of a csv file containing pre-selected
+            experiment ids. Column name for experiment is should be "exp_id".
+        :param num_regions_per_exp:
+            Number of regions per experiment to sample
         :param fov_divisor:
             The number of times to divide a field of view to get the region
             dimensions. Ie if the field of view is 512x512, and region_divisor
@@ -86,37 +103,129 @@ class RegionSampler:
         :param seed:
             Seed for reproducibility
         """
+        if (num_experiments is None or db_url is None) and \
+           selected_experiments_path is None:
+            raise ValueError("Please specify either of num_experiments and "
+                             "db_url or selected experiments. Exiting.")
+        if num_regions_per_exp > fov_divisor ** 2:
+            raise ValueError("Number of requested regions per experiment "
+                             "greater than number of regions created by "
+                             "the fov_divisor. Reduce num_regions_per_exp "
+                             "request.")
+        self.db_url = db_url
+        self._num_experiments = num_experiments
+        self._num_regions_per_exp = num_regions_per_exp
         if not isinstance(artifact_path, Path):
             artifact_path = Path(artifact_path)
         self._artifact_path = artifact_path
-        self._num_regions = num_regions
+        if selected_experiments_path is None:
+            self._num_regions = num_experiments * num_regions_per_exp
+            self._selected_experiments = None
+        else:
+            self._num_regions = \
+                len(selected_experiments_path) * num_regions_per_exp
+            self._selected_experiments = np.sort(pd.read_csv(
+                selected_experiments_path)['exp_id'].to_numpy().astype(str))
         self._fov_divisor = fov_divisor
         self._seed = seed
 
     def sample(self,
-               exclude_motion_border=True):
+               exclude_motion_border: bool = True) -> List[Region]:
         """
-        Samples region candidates without replacement
+        Samples region candidates without replacement equally by experiment
+        depth.
         :param exclude_motion_border:
             Whether to exclude regions outside of motion border
         :return:
         """
-        experiment_ids = self._get_experiment_ids()
-        all_regions = []
-        for experiment_id in experiment_ids:
-            regions = self._get_all_regions_for_experiment(
+        rng = np.random.default_rng(seed=self._seed)
+
+        if self._selected_experiments is None:
+            experiment_ids = self._get_experiment_ids()
+            exp_depth_df = self._retrieve_depths(experiment_ids)
+            self._selected_experiments = self._sample_experiments(exp_depth_df,
+                                                                  rng)
+
+        regions = []
+        for experiment_id in self._selected_experiments:
+            exp_regions = self._get_all_regions_for_experiment(
                 experiment_id=experiment_id,
                 fov_divisor=self._fov_divisor,
                 exclude_motion_border=exclude_motion_border
             )
-            for region in regions:
-                all_regions.append(region)
-
-        rng = np.random.default_rng(seed=self._seed)
-        regions: List[Region] = \
-            rng.choice(all_regions, size=self._num_regions,
-                       replace=False)
+            sub_regions: List[Region] = rng.choice(
+                exp_regions, size=self._num_regions_per_exp)
+            regions.extend(sub_regions)
         return regions
+
+    def _sample_experiments(self,
+                            exp_depth_df: pd.DataFrame,
+                            rng: np.random.Generator) -> np.ndarray:
+        """Sample experiments by equal likelihood in depth without replacement
+        of experiment id.
+
+        Parameters
+        ----------
+        exp_depth_df : pandas.DataFrame
+            DataFrame containing columns id and depth.
+        rng : numpy.random.Generator
+            Seeded random number generator.
+
+        Returns
+        -------
+        selected_experiments : numpy.ndarray, (N,)
+            Sorted array of integer experiment ids that were selected
+            randomly.
+        """
+        indexed_df = exp_depth_df.set_index('imaging_depth')
+        depth_counts = exp_depth_df.groupby('imaging_depth').size()
+        unique_depths = indexed_df.index.unique().sort_values()
+
+        selected_experiments = set()
+        if self._num_experiments > len(exp_depth_df):
+            raise ValueError("Number of experiments requested to sample is "
+                             "greater than the total number of experiments. "
+                             "Please reduce the number of requested samples.")
+        while len(selected_experiments) < self._num_experiments:
+            depth = rng.choice(unique_depths, size=1)[0]
+            if depth_counts.loc[depth] > 1:
+                exp_id = rng.choice(indexed_df.loc[depth, 'exp_id'], size=1)[0]
+            else:
+                exp_id = indexed_df.loc[depth, 'exp_id']
+
+            if exp_id in selected_experiments:
+                continue
+            selected_experiments.add(exp_id)
+
+        return np.sort(list(selected_experiments))
+
+    def _retrieve_depths(self, experiment_ids: List[int]) -> pd.DataFrame:
+        """Query LIMS and retrieve experiment depths given their ids.
+
+        Parameters
+        ----------
+        experiment_ids : list[int]
+            List of integer experiment ids.
+
+        Returns
+        -------
+        depths_df : pandas.DataFrame
+            Pandas DataFrame containing columns id and imaging_depth.
+        """
+        query = "SELECT ophys_e.id as exp_id, ophys_e.imaging_depth_id, "
+        query += "im_depth.id as im_id, im_depth.depth as imaging_depth "
+        query += "FROM ophys_experiments ophys_e "
+        query += "LEFT JOIN imaging_depths im_depth "
+        query += "ON im_depth.id=ophys_e.imaging_depth_id "
+        query += "WHERE ophys_e.id in ("
+        query += ",".join([str(exp_id) for exp_id in experiment_ids])
+        query += ")"
+
+        engine = create_engine(self.db_url)
+        with engine.connect() as conn:
+            data = pd.read_sql(query, conn)
+
+        return data.sort_values('exp_id')
 
     def _get_motion_border_for_experiment(
             self,
@@ -153,7 +262,7 @@ class RegionSampler:
 
         if exclude_motion_border:
             mb = self._get_motion_border_for_experiment(
-                    experiment_id=experiment_id)
+                experiment_id=experiment_id)
         else:
             mb = MotionBorder(
                 left_side=0,
@@ -165,19 +274,17 @@ class RegionSampler:
         within_border_fov_width = fov_width - mb.left_side - mb.right_side
         within_border_fov_height = fov_height - mb.top - mb.bottom
 
-        region_width, region_height = (int(within_border_fov_width /
-                                           fov_divisor),
-                                       int(within_border_fov_height /
-                                           fov_divisor))
-
-        for y in range(mb.top,
-                       fov_height - mb.bottom - region_height + 1,
-                       region_height):
-            for x in range(mb.left_side,
-                           fov_width - mb.right_side - region_width + 1,
-                           region_width):
-                region = Region(x=x,
-                                y=y,
+        region_width, region_height = (
+            int(within_border_fov_width / fov_divisor),
+            int(within_border_fov_height / fov_divisor))
+        for row in range(mb.top,
+                         fov_height - mb.bottom - region_height + 1,
+                         region_height):
+            for col in range(mb.left_side,
+                             fov_width - mb.right_side - region_width + 1,
+                             region_width):
+                region = Region(x=row,
+                                y=col,
                                 width=region_width,
                                 height=region_height,
                                 experiment_id=experiment_id)
@@ -230,9 +337,10 @@ if __name__ == '__main__':
                                  'created')
         parser.add_argument('--config_path', required=True,
                             help='Path to app config')
-        parser.add_argument('--n', required=True,
-                            help='Number of regions to include in the '
-                                 'labeling job')
+        parser.add_argument('--n',
+                            help='Number of experiments to include in the '
+                                 'labeling job',
+                            type=int)
         parser.add_argument('--fov_divisor',
                             help='Amount by which the field of view '
                                  'is divided to obtain the region '
@@ -243,13 +351,55 @@ if __name__ == '__main__':
                                  'is True, then region divisor will divide '
                                  'up the area within the motion border.',
                             type=int, default=4)
+        parser.add_argument('--external_experiment_ids',
+                            help='CSV file containing a column exp_id'
+                                 'whose values are pre-sampled experiments. '
+                                 'Overrides the "--n" argument.',
+                            type=str)
+        parser.add_argument('--n_regions_per_exp',
+                            help='Number of regions per experiment to sample '
+                                 'from each experiment.',
+                            type=int,
+                            default=3)
+        parser.add_argument('--LIMS_user',
+                            help='User name to use to connect to LIMS. '
+                                 'Required if not using '
+                                 'external_experiment_ids.',
+                            type=str)
+        parser.add_argument('--LIMS_password',
+                            help='Password used to connect to LIMS Required '
+                                 'if not using external_experiment_ids.',
+                            type=str)
+        parser.add_argument('--LIMS_host',
+                            help='Name of LIMS host.',
+                            default='limsdb2',
+                            type=str)
+        parser.add_argument('--LIMS_database',
+                            help='Name of LIMS database.',
+                            default='lims2',
+                            type=str)
+        parser.add_argument("--LIMS_port",
+                            help='Port to connect to LIMS on.',
+                            default=5432,
+                            type=str)
         parser.add_argument('--exclude_motion_border', action='store_true',
                             default=True,
                             help='Whether to exclude the motion border when '
                                  'sampling regions')
         parser.add_argument('--artifact_files_dir', required=True,
                             help='Path to labeling artifact hdf5 files')
+        parser.add_argument("--seed",
+                            help='Seed value for the random number generator.',
+                            default=1234,
+                            type=int)
         args = parser.parse_args()
+
+        if (args.LIMS_user is None or args.LIMS_password is None) and \
+           args.external_experiment_ids is None:
+            raise ValueError("No LIMS credentials set and no external "
+                             "experiment is provided. Please specify one or "
+                             "the other. Exiting.")
+
         n = int(args.n)
 
         artifacts_dir = Path(args.artifact_files_dir)
@@ -262,11 +412,20 @@ if __name__ == '__main__':
             with app.app_context():
                 db.create_all()
         app.app_context().push()
+        db_url = f'postgresql+pg8000://{args.LIMS_user}:{args.LIMS_password}' \
+                 f'@{args.LIMS_host}:{args.LIMS_port}/{args.LIMS_database}'
 
-        sampler = RegionSampler(num_regions=n, fov_divisor=args.fov_divisor,
-                                artifact_path=artifacts_dir)
+        sampler = RegionSampler(
+            num_experiments=n,
+            db_url=db_url,
+            num_regions_per_exp=args.n_regions_per_exp,
+            selected_experiments=args.external_experiment_ids,
+            fov_divisor=args.fov_divisor,
+            artifact_path=artifacts_dir,
+            seed=args.seed)
+
         regions = sampler.sample(
-            exclude_motion_border=args.exclude_motion_border
+            exclude_motion_border=args.exclude_motion_border,
         )
         populate_labeling_job(regions=regions)
 

--- a/src/server/cell_labeling_app/database/populate_labeling_job.py
+++ b/src/server/cell_labeling_app/database/populate_labeling_job.py
@@ -171,10 +171,10 @@ class RegionSampler:
                                            fov_divisor))
 
         for y in range(mb.top,
-                       fov_height - mb.bottom,
+                       fov_height - mb.bottom - region_height + 1,
                        region_height):
             for x in range(mb.left_side,
-                           fov_width - mb.right_side,
+                           fov_width - mb.right_side - region_width + 1,
                            region_width):
                 region = Region(x=x,
                                 y=y,

--- a/src/server/cell_labeling_app/endpoints/endpoints.py
+++ b/src/server/cell_labeling_app/endpoints/endpoints.py
@@ -229,11 +229,26 @@ def get_fov_bounds():
     x_min, x_max = x.min(), (x + widths).max()
     y_min, y_max = y.min(), (y + heights).max()
 
-    return {
-        'x': [float(x_min), float(x_max)],
+    # Find the larger box, either the region box or the box containing all ROIs
+    # that are contained within or overlap within the box
+    # The box containing all ROIs will be smaller in the case there are few
+    # ROIs within the region, and they are close together.
+    # This ensures that we always return at least the region box
+    # Region x is row and region y and col
+    x_range = [
+        min(float(x_min), region.y),
+        max(float(x_max), region.y + region.width)
+    ]
 
+    y_range = [
         # Reversing because origin of plot is top-left instead of bottom-left
-        'y': [float(y_max), float(y_min)]
+        max(float(y_max), region.x + region.height),
+        min(float(y_min), region.y)
+    ]
+
+    return {
+        'x': x_range,
+        'y': y_range
     }
 
 

--- a/src/server/cell_labeling_app/endpoints/endpoints.py
+++ b/src/server/cell_labeling_app/endpoints/endpoints.py
@@ -14,7 +14,9 @@ from cell_labeling_app.database.database import db
 from cell_labeling_app.database.schemas import JobRegion, \
     UserLabels, UserRoiExtra
 from cell_labeling_app.util import util
-from cell_labeling_app.util.util import get_artifacts_path
+from cell_labeling_app.util.util import get_artifacts_path, \
+    get_user_has_labeled, get_completed_regions, \
+    get_total_regions_in_labeling_job
 from cell_labeling_app.imaging_plane_artifacts import ArtifactFile
 from cell_labeling_app.util.util import get_next_region
 
@@ -342,6 +344,24 @@ def find_roi_at_coordinates():
 
     return {
         'roi_id': None
+    }
+
+
+@api.route('/get_label_stats', methods=['GET'])
+def get_label_stats():
+    """
+    Gets stats on user label counts, and num. remaining
+    :return:
+        Dict of stats
+    """
+    user_has_labeled = get_user_has_labeled()
+    completed = get_completed_regions()
+    total = get_total_regions_in_labeling_job()
+
+    return {
+        'n_user_has_labeled': len(user_has_labeled),
+        'n_total': total,
+        'n_completed': len(completed)
     }
 
 

--- a/src/server/cell_labeling_app/endpoints/endpoints.py
+++ b/src/server/cell_labeling_app/endpoints/endpoints.py
@@ -243,7 +243,7 @@ def get_fov_bounds():
     y_range = [
         # Reversing because origin of plot is top-left instead of bottom-left
         max(float(y_max), region.x + region.height),
-        min(float(y_min), region.y)
+        min(float(y_min), region.x)
     ]
 
     return {

--- a/src/server/cell_labeling_app/endpoints/endpoints.py
+++ b/src/server/cell_labeling_app/endpoints/endpoints.py
@@ -361,7 +361,9 @@ def get_label_stats():
     return {
         'n_user_has_labeled': len(user_has_labeled),
         'n_total': total,
-        'n_completed': len(completed)
+        'n_completed': len(completed),
+        'num_labelers_required_per_region':
+            current_app.config['LABELS_PER_REGION_LIMIT']
     }
 
 

--- a/src/server/cell_labeling_app/imaging_plane_artifacts.py
+++ b/src/server/cell_labeling_app/imaging_plane_artifacts.py
@@ -67,15 +67,15 @@ class ArtifactFile:
     def rois(self) -> List[dict]:
         with h5py.File(self._path, 'r') as f:
             return json.loads((f['rois'][()]))
-    
+
     @property
     def motion_border(self) -> MotionBorder:
         with h5py.File(self._path, 'r') as f:
             mb = json.loads(f['motion_border'][()])
-            mb = MotionBorder(left_side=mb['left_side'],
-                              right_side=mb['right_side'],
-                              top=mb['top'],
-                              bottom=mb['bottom'])
+            mb = MotionBorder(left_side=int(mb['left_side']),
+                              right_side=int(mb['right_side']),
+                              top=int(mb['top']),
+                              bottom=int(mb['bottom']))
         return mb
 
     def get_projection(self, projection_type: str) -> np.ndarray:

--- a/src/server/cell_labeling_app/main.py
+++ b/src/server/cell_labeling_app/main.py
@@ -51,9 +51,10 @@ if __name__ == '__main__':
     config_file = Path(args.config_file)
 
     app = create_app(config_file=config_file, debug=args.debug)
+    port = app.config['PORT']
 
     if args.debug:
-        app.run(debug=True)
+        app.run(debug=True, port=port)
     else:
         from waitress import serve
-        serve(app, threads=args.threads)
+        serve(app, port=port, threads=args.threads)

--- a/src/server/cell_labeling_app/main.py
+++ b/src/server/cell_labeling_app/main.py
@@ -1,6 +1,8 @@
 import logging
+import uuid
 from pathlib import Path
 
+import argschema
 from flask import Flask
 
 from cell_labeling_app.database.database import db
@@ -9,52 +11,89 @@ from cell_labeling_app.endpoints.user_authentication import users
 from cell_labeling_app.user_authentication.user_authentication import login
 
 
-def create_app(config_file: Path, debug=False):
-    if not config_file.exists():
-        raise ValueError('Config file does not exist')
-    if not config_file.suffix == '.py':
-        raise ValueError('Config file must be a python module ending in '
-                           '".py"')
+class AppSchema(argschema.ArgSchema):
+    SQLALCHEMY_DATABASE_URI = argschema.fields.Str(
+        required=True,
+        description='Database URI',
+        validate=lambda x: Path(x.replace('sqlite:///', '')).exists()
+    )
+    ARTIFACT_DIR = argschema.fields.InputDir(
+        required=True,
+        description='Path to h5 files storing data required for the '
+                    'app to run'
+    )
+    PREDICTIONS_DIR = argschema.fields.InputDir(
+        required=True,
+        description='Path to pre-classification predictions'
+    )
+    PORT = argschema.fields.Integer(
+        default=5000,
+        description='Port the app should run on'
+    )
+    FIELD_OF_VIEW_DIMENSIONS = argschema.fields.Tuple(
+        (argschema.fields.Int, argschema.fields.Int),
+        default=(512, 512),
+        description='Field of view dimensions'
+    )
+    LOG_FILE = argschema.fields.OutputFile(
+        required=True,
+        description='Path to where logs should be written'
+    )
+    LABELS_PER_REGION_LIMIT = argschema.fields.Integer(
+        default=3,
+        allow_none=True,
+        description='Limits the number of labelers who need to label a region '
+                    'to mark it "complete". Once it is "complete" it is not '
+                    'shown to other labelers. If None, a region will be shown '
+                    'to all labelers regardless of the number of times it has '
+                    'been labeled. '
+    )
+    debug = argschema.fields.Boolean(
+        default=False,
+        description='Whether to enable debug mode (more logging, '
+                    'autoreload of server on code change)'
+    )
+    num_threads = argschema.fields.Integer(
+        default=16,
+        description='Number of threads to use for the webserver'
+    )
 
-    template_dir = (Path(__file__).parent.parent.parent / 'client').resolve()
-    static_dir = template_dir
-    app = Flask(__name__, static_folder=static_dir,
-                          template_folder=str(template_dir))
-    app.register_blueprint(api)
-    app.config.from_pyfile(filename=str(config_file))
-    db.init_app(app)
-    app.register_blueprint(users)
-    app.secret_key = app.config['SESSION_SECRET_KEY']
 
-    log_level = logging.DEBUG if debug else logging.INFO
-    logging.basicConfig(filename=app.config['LOG_FILE'], level=log_level)
+class App(argschema.ArgSchemaParser):
+    default_schema = AppSchema
 
-    login.init_app(app)
-    return app
+    def run(self):
+        app = self._create_app()
+        port = self.args['PORT']
+
+        if self.args['debug']:
+            app.run(debug=True, port=port)
+        else:
+            from waitress import serve
+            serve(app, port=port, threads=self.args['num_threads'])
+
+    def _create_app(self):
+        template_dir = (
+                    Path(__file__).parent.parent.parent / 'client').resolve()
+        static_dir = template_dir
+        app = Flask(__name__, static_folder=static_dir,
+                    template_folder=str(template_dir))
+        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+        app.config['SESSION_SECRET_KEY'] = str(uuid.uuid4())
+        app.register_blueprint(api)
+        for k, v in self.args.items():
+            app.config[k] = v
+        db.init_app(app)
+        app.register_blueprint(users)
+        app.secret_key = app.config['SESSION_SECRET_KEY']
+
+        log_level = logging.DEBUG if self.args['debug'] else logging.INFO
+        logging.basicConfig(filename=app.config['LOG_FILE'], level=log_level)
+
+        login.init_app(app)
+        return app
 
 
 if __name__ == '__main__':
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--config_file', help='Path to config file',
-                        required=True)
-    parser.add_argument(
-        '--debug', action='store_true',
-        help='Enable automatic reloading when server-side code changes; '
-             'enable debug level logging')
-    parser.add_argument('--threads', default=16, help='Number of threads for '
-                                                      'the web server',
-                        type=int)
-    args = parser.parse_args()
-
-    config_file = Path(args.config_file)
-
-    app = create_app(config_file=config_file, debug=args.debug)
-    port = app.config['PORT']
-
-    if args.debug:
-        app.run(debug=True, port=port)
-    else:
-        from waitress import serve
-        serve(app, port=port, threads=args.threads)
+    app = App()
+    app.run()

--- a/src/server/cell_labeling_app/main.py
+++ b/src/server/cell_labeling_app/main.py
@@ -101,13 +101,6 @@ class App(argschema.ArgSchemaParser):
         app.register_blueprint(users)
         app.secret_key = app.config['SESSION_SECRET_KEY']
 
-        log_level = logging.DEBUG if self.args['debug'] else logging.INFO
-        logging.basicConfig(
-            filename=app.config['LOG_FILE'],
-            level=log_level,
-            format='%(asctime)s %(levelname)-8s %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S')
-
         login.init_app(app)
         self._create_backup_manager(app)
 
@@ -127,4 +120,14 @@ class App(argschema.ArgSchemaParser):
 
 if __name__ == '__main__':
     app = App()
+
+    log_level = logging.DEBUG if app.args['debug'] else logging.INFO
+    logging.basicConfig(
+        filename=app.args['LOG_FILE'],
+        level=log_level,
+        format='%(name)s: %(asctime)s %(levelname)-8s %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        force=True
+    )
+
     app.run()

--- a/src/server/cell_labeling_app/main.py
+++ b/src/server/cell_labeling_app/main.py
@@ -72,9 +72,11 @@ class AppSchema(argschema.ArgSchema):
 
 
 class App(argschema.ArgSchemaParser):
+    """The main driver for the app."""
     default_schema = AppSchema
 
     def run(self):
+        """Launches webserver running app"""
         app = self._create_app()
         port = self.args['PORT']
 
@@ -85,6 +87,7 @@ class App(argschema.ArgSchemaParser):
             serve(app, port=port, threads=self.args['num_threads'])
 
     def _create_app(self):
+        """Creates a flask app"""
         template_dir = (
                     Path(__file__).parent.parent.parent / 'client').resolve()
         static_dir = template_dir
@@ -107,6 +110,7 @@ class App(argschema.ArgSchemaParser):
         return app
 
     def _create_backup_manager(self, app):
+        """Starts a backup manager running in the background in a new thread"""
         database_path = Path(self.args['database_path'])
         backup_manager = BackupManager(
             app=app,

--- a/src/server/cell_labeling_app/util/util.py
+++ b/src/server/cell_labeling_app/util/util.py
@@ -1,4 +1,5 @@
 import base64
+import random
 from io import BytesIO
 from pathlib import Path
 from typing import Dict, Tuple, Optional, List
@@ -8,10 +9,14 @@ import matplotlib.cm
 import numpy as np
 import pandas as pd
 from PIL import Image
+from cell_labeling_app.database.database import db
 from flask import current_app
 
-from cell_labeling_app.database.schemas import JobRegion
+from cell_labeling_app.database.schemas import JobRegion, UserLabels, \
+    LabelingJob
 from cell_labeling_app.imaging_plane_artifacts import ArtifactFile
+from flask_login import current_user
+from sqlalchemy import func, desc
 
 
 def _is_roi_within_region(roi: Dict, region: JobRegion,
@@ -222,3 +227,78 @@ def get_artifacts_path(experiment_id: str):
     artifact_dir = Path(current_app.config['ARTIFACT_DIR'])
     artifact_path = artifact_dir / f'{experiment_id}_artifacts.h5'
     return artifact_path
+
+
+def _get_completed_regions(job_id: int) -> List[str]:
+    """
+    This returns the regions with sufficient number of labels
+    :param job_id
+        The job id
+    :rtype: list of string
+        list of completed region ids
+    """
+    region_label_counts = \
+        (db.session
+         .query(UserLabels.region_id,
+                func.count())
+         .join(JobRegion, JobRegion.id == UserLabels.region_id)
+         .filter(JobRegion.job_id == job_id)
+         .group_by(UserLabels.region_id)
+         .all())
+    region_label_counts = pd.DataFrame.from_records(
+        region_label_counts, columns=['region_id', 'count'])
+    regions_with_enough_labels = \
+        region_label_counts.loc[
+            region_label_counts['count'] ==
+            current_app.config['LABELS_PER_REGION_LIMIT'],
+            'region_id'].tolist()
+    return regions_with_enough_labels
+
+
+def get_next_region() -> Optional[JobRegion]:
+    """Samples a region randomly from a set of candidate regions.
+    The candidate regions are those that have not already been labeled by the
+    labeler and those that have not been labeled enough times by other
+    labelers
+    :rtype: optional JobRegion
+        JobRegion, if a candidate region exists, otherwise None
+    """
+    # job id is most recently created job id
+    job_id = db.session.query(LabelingJob.job_id).order_by(desc(
+        LabelingJob.date)).first()[0]
+
+    # Get all region ids user has labeled
+    user_has_labeled = \
+        (db.session
+         .query(UserLabels.region_id)
+         .join(JobRegion, JobRegion.id == UserLabels.region_id)
+         .filter(JobRegion.job_id == job_id,
+                 UserLabels.user_id == current_user.get_id())
+         .all())
+    user_has_labeled = [region.region_id for region in user_has_labeled]
+
+    if current_app.config['LABELS_PER_REGION_LIMIT'] is not None:
+        regions_with_enough_labels = _get_completed_regions(job_id=job_id)
+        exclude_regions = user_has_labeled + regions_with_enough_labels
+    else:
+        exclude_regions = user_has_labeled
+
+    # Get initial next region candidates query
+    next_region_candidates = \
+        (db.session
+         .query(JobRegion)
+         .filter(JobRegion.job_id == job_id))
+
+    # Add filter to next_region_candidates query so user does not label a
+    # region that has already been labeled
+    for region_id in exclude_regions:
+        next_region_candidates = next_region_candidates.filter(
+            JobRegion.id != region_id)
+
+    next_region_candidates = next_region_candidates.all()
+    next_region: Optional[JobRegion]
+    if not next_region_candidates:
+        next_region = None
+    else:
+        next_region = random.choice(next_region_candidates)
+    return next_region

--- a/src/server/cell_labeling_app/util/util.py
+++ b/src/server/cell_labeling_app/util/util.py
@@ -249,7 +249,7 @@ def _get_completed_regions(job_id: int) -> List[str]:
         region_label_counts, columns=['region_id', 'count'])
     regions_with_enough_labels = \
         region_label_counts.loc[
-            region_label_counts['count'] ==
+            region_label_counts['count'] >=
             current_app.config['LABELS_PER_REGION_LIMIT'],
             'region_id'].tolist()
     return regions_with_enough_labels

--- a/src/server/cell_labeling_app/util/util.py
+++ b/src/server/cell_labeling_app/util/util.py
@@ -37,8 +37,8 @@ def _is_roi_within_region(roi: Dict, region: JobRegion,
         True if ROI is within region else False
     """
     region_mask = np.zeros(field_of_view_dimension, dtype='uint8')
-    region_mask[region.x:region.x+region.width,
-                region.y:region.y+region.height] = 1
+    region_mask[region.x:region.x+region.height,
+                region.y:region.y+region.width] = 1
 
     roi_mask = np.zeros(field_of_view_dimension, dtype='uint8')
     roi_mask[roi['y']:roi['y']+roi['height'],

--- a/tests/server/database/test_populate_labeling_job.py
+++ b/tests/server/database/test_populate_labeling_job.py
@@ -11,7 +11,6 @@ from cell_labeling_app.database.schemas import JobRegion
 from cell_labeling_app.database.populate_labeling_job import RegionSampler, \
     FIELD_OF_VIEW_DIMENSIONS, populate_labeling_job, Region
 from cell_labeling_app.imaging_plane_artifacts import MotionBorder
-from cell_labeling_app.main import App
 from flask import Flask
 
 

--- a/tests/server/database/test_populate_labeling_job.py
+++ b/tests/server/database/test_populate_labeling_job.py
@@ -11,6 +11,7 @@ from cell_labeling_app.database.schemas import JobRegion
 from cell_labeling_app.main import create_app
 from cell_labeling_app.database.populate_labeling_job import RegionSampler, \
     FIELD_OF_VIEW_DIMENSIONS, populate_labeling_job, Region
+from cell_labeling_app.imaging_plane_artifacts import MotionBorder
 
 
 class TestPopulateLabelingJob:
@@ -20,17 +21,21 @@ class TestPopulateLabelingJob:
         self.db_fp = tempfile.NamedTemporaryFile('w', suffix='.db')
         self.config_fp = tempfile.NamedTemporaryFile('w', suffix='.py')
 
-        self.motion_border_x = 10
-        self.motion_border_y = 20
+        self.motion_border = MotionBorder(
+            top=30,
+            bottom=30,
+            left_side=30,
+            right_side=28
+        )
 
         for exp_id in (1,):
             exp_id_path = Path(self.artifacts_path.name)
             with h5py.File(exp_id_path / f'{exp_id}_artifacts.h5', 'w') as f:
                 mb = {
-                    'top': self.motion_border_y,
-                    'right_side': self.motion_border_x,
-                    'bottom': self.motion_border_y,
-                    'left_side': self.motion_border_x
+                    'top': self.motion_border.top,
+                    'right_side': self.motion_border.right_side,
+                    'bottom': self.motion_border.bottom,
+                    'left_side': self.motion_border.left_side
                 }
                 mb = json.dumps(mb)
                 f.create_dataset('motion_border', data=mb)
@@ -68,15 +73,43 @@ LOG_FILE = ''
             exclude_motion_border=exclude_motion_border
         )
         if exclude_motion_border:
-            motion_border_x = self.motion_border_x
-            motion_border_y = self.motion_border_y
+            motion_border = self.motion_border
         else:
-            motion_border_x = 0
-            motion_border_y = 0
+            motion_border = MotionBorder(
+                top=0,
+                bottom=0,
+                left_side=0,
+                right_side=0
+            )
         self._regions_are_expected(regions=regions,
-                                   motion_border_y=motion_border_y,
-                                   motion_border_x=motion_border_x,
+                                   motion_border=motion_border,
                                    fov_divisor=fov_divisor)
+
+    @pytest.mark.parametrize('fov_divisor', (1, 2, 4))
+    @pytest.mark.parametrize('exclude_motion_border', (True, False))
+    def test_get_all_regions_for_experiment(self, fov_divisor,
+                                            exclude_motion_border):
+        """tests that total number of regions is correct and all regions
+        are as expected"""
+        sampler = RegionSampler(num_regions=1, fov_divisor=fov_divisor,
+                                artifact_path=self.artifacts_path.name)
+        regions = sampler._get_all_regions_for_experiment(
+            experiment_id='1', exclude_motion_border=exclude_motion_border,
+            fov_divisor=fov_divisor)
+
+        if exclude_motion_border:
+            motion_border = self.motion_border
+        else:
+            motion_border = MotionBorder(
+                top=0,
+                bottom=0,
+                left_side=0,
+                right_side=0
+            )
+        self._regions_are_expected(regions=regions,
+                                   motion_border=motion_border,
+                                   fov_divisor=fov_divisor)
+        assert len(regions) == fov_divisor ** 2
 
     @pytest.mark.parametrize('num_regions', (6, 7))
     @pytest.mark.parametrize('exclude_motion_border', (True, False))
@@ -97,33 +130,38 @@ LOG_FILE = ''
         assert num_added == num_regions
 
         if exclude_motion_border:
-            motion_border_x = self.motion_border_x
-            motion_border_y = self.motion_border_y
+            motion_border = self.motion_border
         else:
-            motion_border_x = 0
-            motion_border_y = 0
+            motion_border = MotionBorder(
+                top=0,
+                bottom=0,
+                left_side=0,
+                right_side=0
+            )
         regions = db.session.query(JobRegion).all()
         self._regions_are_expected(regions=regions,
-                                   motion_border_x=motion_border_x,
-                                   motion_border_y=motion_border_y,
+                                   motion_border=motion_border,
                                    fov_divisor=fov_divisor)
 
     @staticmethod
     def _regions_are_expected(regions: List[Region],
-                              motion_border_x: int,
-                              motion_border_y: int,
+                              motion_border: MotionBorder,
                               fov_divisor: int):
         fov_dims = FIELD_OF_VIEW_DIMENSIONS
 
         for region in regions:
-            assert region.x >= motion_border_x
+            assert region.x >= motion_border.left_side
             assert region.x + region.width <= fov_dims[0] - \
-                   motion_border_x
-            assert region.y >= motion_border_y
+                   motion_border.right_side
+            assert region.y >= motion_border.top
             assert region.y + region.height <= fov_dims[1] - \
-                   motion_border_y
+                   motion_border.bottom
 
-            assert region.width == int((fov_dims[0] - motion_border_x * 2) /
-                                       fov_divisor)
-            assert region.height == int((fov_dims[1] - motion_border_y * 2) /
-                                        fov_divisor)
+            assert region.width == \
+                   int((fov_dims[0] -
+                        motion_border.left_side - motion_border.right_side) /
+                       fov_divisor)
+            assert region.height == \
+                   int((fov_dims[1] -
+                        motion_border.top - motion_border.bottom) /
+                       fov_divisor)

--- a/tests/server/database/test_populate_labeling_job.py
+++ b/tests/server/database/test_populate_labeling_job.py
@@ -3,6 +3,10 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import List
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
 
 import h5py
 import pytest
@@ -55,13 +59,24 @@ class TestPopulateLabelingJob:
 
     @pytest.mark.parametrize('fov_divisor', (1, 2, 4))
     @pytest.mark.parametrize('exclude_motion_border', (True, False))
-    def test_sampler(self, fov_divisor, exclude_motion_border):
+    def test_sampler(self,
+                     fov_divisor,
+                     exclude_motion_border):
         """tests that sampled regions are as expected"""
-        sampler = RegionSampler(num_regions=1, fov_divisor=fov_divisor,
-                                artifact_path=self.artifacts_path.name)
-        regions = sampler.sample(
-            exclude_motion_border=exclude_motion_border
-        )
+        with patch.object(RegionSampler,
+                          '_sample_experiments',
+                          return_value=(1,)), \
+             patch.object(RegionSampler,
+                          '_retrieve_depths',
+                          return_value=MagicMock(spec=pd.DataFrame)):
+            sampler = RegionSampler(num_experiments=1,
+                                    num_regions_per_exp=1,
+                                    fov_divisor=fov_divisor,
+                                    db_url='',
+                                    artifact_path=self.artifacts_path.name)
+            regions = sampler.sample(
+                exclude_motion_border=exclude_motion_border,
+            )
         if exclude_motion_border:
             motion_border = self.motion_border
         else:
@@ -81,7 +96,10 @@ class TestPopulateLabelingJob:
                                             exclude_motion_border):
         """tests that total number of regions is correct and all regions
         are as expected"""
-        sampler = RegionSampler(num_regions=1, fov_divisor=fov_divisor,
+        sampler = RegionSampler(num_experiments=1,
+                                num_regions_per_exp=1,
+                                fov_divisor=fov_divisor,
+                                db_url='',
                                 artifact_path=self.artifacts_path.name)
         regions = sampler._get_all_regions_for_experiment(
             experiment_id='1', exclude_motion_border=exclude_motion_border,
@@ -101,18 +119,91 @@ class TestPopulateLabelingJob:
                                    fov_divisor=fov_divisor)
         assert len(regions) == fov_divisor ** 2
 
+    @pytest.mark.parametrize('fov_divisor', (1, 2, 4))
+    @pytest.mark.parametrize('exclude_motion_border', (True, False))
+    def test_pre_sampled_ids(self,
+                             fov_divisor,
+                             exclude_motion_border):
+        """tests that sampled regions are as expected"""
+        csv_file = tempfile.mkstemp()
+        id_df = pd.DataFrame(data={"exp_id": (1,)})
+        id_df.to_csv(csv_file[1])
+
+        with patch.object(RegionSampler,
+                          '_retrieve_depths',
+                          return_value=MagicMock(spec=pd.DataFrame)):
+            sampler = RegionSampler(selected_experiments_path=csv_file[1],
+                                    num_regions_per_exp=1,
+                                    fov_divisor=fov_divisor,
+                                    db_url='',
+                                    artifact_path=self.artifacts_path.name)
+            regions = sampler.sample(
+                exclude_motion_border=exclude_motion_border,
+            )
+
+        if exclude_motion_border:
+            motion_border = self.motion_border
+        else:
+            motion_border = MotionBorder(
+                top=0,
+                bottom=0,
+                left_side=0,
+                right_side=0
+            )
+        self._regions_are_expected(regions=regions,
+                                   motion_border=motion_border,
+                                   fov_divisor=fov_divisor)
+
+    def test_raises(self):
+        with pytest.raises(ValueError, match=r'Please specify either .*'):
+            RegionSampler(num_regions_per_exp=1,
+                          artifact_path=self.artifacts_path.name)
+
+        with pytest.raises(ValueError, match=r'Number of requested .*'):
+            RegionSampler(num_experiments=1,
+                          db_url='',
+                          num_regions_per_exp=3,
+                          fov_divisor=1,
+                          artifact_path=self.artifacts_path.name)
+
+    def test_depth_exp_id_sampling(self):
+        """Test that the sampling algorithm selects the expected experiments.
+        """
+        data_frame = pd.DataFrame(data={"exp_id": [1, 2, 3, 4],
+                                        "imaging_depth": [10, 10, 10, 12],
+                                        "im_id": [7, 8, 9, 10]})
+
+        rng = np.random.default_rng(1234)
+        sampler = RegionSampler(artifact_path=self.artifacts_path.name,
+                                num_experiments=3,
+                                db_url='',
+                                num_regions_per_exp=1,
+                                fov_divisor=2)
+        selected_experiments = sampler._sample_experiments(
+            data_frame,
+            rng)
+        np.testing.assert_equal(selected_experiments, [1, 3, 4])
+
     @pytest.mark.parametrize('num_regions', (6, 7))
     @pytest.mark.parametrize('exclude_motion_border', (True, False))
     @pytest.mark.parametrize('fov_divisor', (4,))
     def test_create_labeling_job(self, num_regions, exclude_motion_border,
                                  fov_divisor):
         """tests that region entries populated in db are as expected"""
-        sampler = RegionSampler(num_regions=num_regions,
-                                fov_divisor=fov_divisor,
-                                artifact_path=self.artifacts_path.name)
-        regions = sampler.sample(
-            exclude_motion_border=exclude_motion_border
-        )
+        with patch.object(RegionSampler,
+                          '_sample_experiments',
+                          return_value=(1,)), \
+             patch.object(RegionSampler,
+                          '_retrieve_depths',
+                          return_value=MagicMock(spec=pd.DataFrame)):
+            sampler = RegionSampler(num_experiments=1,
+                                    num_regions_per_exp=num_regions,
+                                    fov_divisor=fov_divisor,
+                                    db_url='',
+                                    artifact_path=self.artifacts_path.name)
+            regions = sampler.sample(
+                exclude_motion_border=exclude_motion_border
+            )
         populate_labeling_job(regions=regions)
 
         num_added = db.session.query(JobRegion).filter_by(
@@ -140,12 +231,12 @@ class TestPopulateLabelingJob:
         fov_dims = FIELD_OF_VIEW_DIMENSIONS
 
         for region in regions:
-            assert region.x >= motion_border.left_side
-            assert region.x + region.width <= fov_dims[0] - \
-                   motion_border.right_side
-            assert region.y >= motion_border.top
-            assert region.y + region.height <= fov_dims[1] - \
+            assert region.x >= motion_border.top
+            assert region.x + region.height <= fov_dims[1] - \
                    motion_border.bottom
+            assert region.y >= motion_border.left_side
+            assert region.y + region.width <= fov_dims[1] - \
+                   motion_border.right_side
 
             assert region.width == \
                    int((fov_dims[0] -

--- a/tests/server/util/test_util.py
+++ b/tests/server/util/test_util.py
@@ -1,0 +1,111 @@
+import json
+import tempfile
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch, MagicMock
+
+import pytest
+from cell_labeling_app.database.database import db
+from cell_labeling_app.database.populate_labeling_job import Region
+from cell_labeling_app.database.schemas import UserLabels
+from cell_labeling_app.main import create_app
+from cell_labeling_app.database.schemas import User, LabelingJob, JobRegion
+from sqlalchemy import desc
+
+from cell_labeling_app.util.util import get_next_region
+
+
+class TestGetNextRegion:
+    @classmethod
+    def setup_class(cls):
+        cls.db_fp = tempfile.NamedTemporaryFile('w', suffix='.db')
+        cls.config_fp = tempfile.NamedTemporaryFile('w', suffix='.py')
+
+    def _init_db(self, labels_per_region_limit: Optional[int] = None):
+        db_fp = tempfile.NamedTemporaryFile('w', suffix='.db')
+        config_fp = tempfile.NamedTemporaryFile('w', suffix='.py')
+
+        config = f'''
+SQLALCHEMY_DATABASE_URI = f'sqlite:///{db_fp.name}'
+SESSION_SECRET_KEY = 1
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+LOG_FILE = ''
+LABELS_PER_REGION_LIMIT = {labels_per_region_limit}
+        '''
+        config_fp.write(config)
+        config_fp.seek(0)
+
+        app = create_app(config_file=Path(config_fp.name))
+        with app.app_context():
+            db.create_all()
+        app.app_context().push()
+
+        self.app = app
+
+        self.db_fp = db_fp
+        self.config_fp = config_fp
+
+        self.user_ids = list(range(4))
+        self._populate_users()
+        self._populate_labeling_job()
+
+    def teardown(self):
+        self.config_fp.close()
+        self.db_fp.close()
+
+    def _populate_users(self):
+        for user_id in self.user_ids:
+            user = User(id=str(user_id))
+            db.session.add(user)
+            db.session.commit()
+
+    @staticmethod
+    def _populate_labeling_job():
+        job = LabelingJob()
+        db.session.add(job)
+
+        job_id = db.session.query(LabelingJob.job_id).order_by(desc(
+            LabelingJob.date)).first()[0]
+
+        region = Region(
+            x=0,
+            y=0,
+            experiment_id='0',
+            width=10,
+            height=10
+        )
+        job_region = JobRegion(job_id=job_id,
+                               experiment_id=region.experiment_id,
+                               x=region.x, y=region.y, width=region.width,
+                               height=region.height)
+        db.session.add(job_region)
+        db.session.commit()
+
+    @pytest.mark.parametrize('labels_per_region_limit', (None, 3))
+    def test_get_next_region(self, labels_per_region_limit):
+        """Tests that if labels_per_region_limit, then when enough labels
+        have been given for a single region, that it is not sampled. If no
+        limit, then sampling it again is fine"""
+        self._init_db(labels_per_region_limit=labels_per_region_limit)
+        user_ids = self.user_ids[:-1]
+
+        # ALl users but last give a label for the same region
+        # (there is only 1 region)
+        for user_id in user_ids:
+            user_labels = UserLabels(user_id=str(user_id), region_id=1,
+                                     labels=json.dumps({}))
+            db.session.add(user_labels)
+        db.session.commit()
+
+        # The last user tries to get a region. If labels_per_region_limit,
+        # then this user should not be able to sample the region
+        with patch('cell_labeling_app.util.util.current_user') as mock_user:
+            mock_user.get_id = MagicMock(return_value='3')
+            next_region = get_next_region()
+
+        if labels_per_region_limit is not None:
+            assert next_region is None
+        else:
+            assert next_region.id == 1
+
+


### PR DESCRIPTION
This PR addresses several things:
- adds ability to limit number of labels required to mark a region as "complete". Note, this does not handle the race condition where multiple people happen to load the same region at the same time and all submit. It only prevents the loading of a new region that has been labeled enough times
- Add experiment id and region id to UI
- adds `BackupManager` to do backups every `frequency` seconds, if there has been a change to the number of labels
- Use argschema for starting the app
- fixes logging to file (file wasn't getting created)
- Fix bug in which default view was too zoomed in to ROIs when there were few ROIs in the region close together. New behavior is to at minimum show the whole region
- Stores contrast settings per projection type using browser cookies