### PR TITLE
use get_thumbnail_video_from_artifact_file

### DIFF
--- a/src/server/cell_labeling_app/endpoints/endpoints.py
+++ b/src/server/cell_labeling_app/endpoints/endpoints.py
@@ -8,7 +8,8 @@ from PIL import Image
 from flask import render_template, request, send_file, Blueprint, \
     current_app, Request
 from flask_login import current_user
-from ophys_etl.utils.thumbnail_video_generator import VideoGenerator
+from ophys_etl.roi_cell_classifier.video_utils import (
+    get_thumbnail_video_from_artifact_file)
 
 from cell_labeling_app.database.database import db
 from cell_labeling_app.database.schemas import JobRegion, \
@@ -148,9 +149,6 @@ def get_video():
 
     artifact_path = get_artifacts_path(experiment_id=experiment_id)
 
-    af = ArtifactFile(path=artifact_path)
-    video_generator = VideoGenerator(video_data=af.video)
-
     region = (db.session.query(JobRegion)
               .filter(JobRegion.id == region_id)
               .first())
@@ -183,8 +181,9 @@ def get_video():
 
     roi_list = rois if include_all_roi_masks else None
 
-    video = video_generator.get_thumbnail_video_from_roi(
-        this_roi,
+    video = get_thumbnail_video_from_artifact_file(
+        artifact_path=artifact_path,
+        roi=this_roi,
         padding=padding,
         quality=9,
         timesteps=timesteps,

--- a/src/server/cell_labeling_app/imaging_plane_artifacts.py
+++ b/src/server/cell_labeling_app/imaging_plane_artifacts.py
@@ -59,11 +59,6 @@ class ArtifactFile:
         return self._path.name.split('_')[0]
 
     @property
-    def video(self) -> np.ndarray:
-        with h5py.File(self._path, 'r') as f:
-            return f['video_data'][()]
-
-    @property
     def rois(self) -> List[dict]:
         with h5py.File(self._path, 'r') as f:
             return json.loads((f['rois'][()]))


### PR DESCRIPTION
instead of using VideoGenerator, which reads whole video into memory

If we merge

https://github.com/AllenInstitute/ophys_etl_pipelines/pull/465

this is what I propose we do to speed up the loading of thumbnail videos in the app