### PR TITLE
fix remaining regions for user. The bug is that we were subtracting o…

### DIFF
--- a/src/client/app.js
+++ b/src/client/app.js
@@ -1236,13 +1236,14 @@ class CellLabelingApp {
         .then(stats => {
             const total = stats['n_total'];
             const completed = stats['n_completed'];
+            const completedByOthers = stats['n_completed_by_others'];
             const userLabeled = stats['n_user_has_labeled'];
             const numLabelersRequiredPerRegion = stats['num_labelers_required_per_region'];
             const totalProgress = completed / total;
-            const userProgress = userLabeled / (total - completed);
+            const userProgress = userLabeled / (total - completedByOthers);
 
             const progressHtml = `
-                <p>${userLabeled} / ${total - completed} labeled</p>
+                <p>${userLabeled} / ${total - completedByOthers} labeled</p>
                 <div class="progress">
                     <div class="progress-bar" role="progressbar" style="width: ${userProgress * 100}%;" aria-valuenow="${userLabeled}" aria-valuemin="0" aria-valuemax="${total}"></div>
                 </div>

--- a/src/server/cell_labeling_app/endpoints/endpoints.py
+++ b/src/server/cell_labeling_app/endpoints/endpoints.py
@@ -349,12 +349,14 @@ def get_label_stats():
     """
     user_has_labeled = get_user_has_labeled()
     completed = get_completed_regions()
+    completed_by_others = get_completed_regions(exclude_current_user=True)
     total = get_total_regions_in_labeling_job()
 
     return {
         'n_user_has_labeled': len(user_has_labeled),
         'n_total': total,
         'n_completed': len(completed),
+        'n_completed_by_others': len(completed_by_others),
         'num_labelers_required_per_region':
             current_app.config['LABELERS_REQUIRED_PER_REGION']
     }


### PR DESCRIPTION
…ff regions which the user contributed to "completing" as well as regions which others contributed to "completing". So the number remaining for the user could be less than the number completed (ie 54 / 30 regions completed), which doesn't make sense. The new logic only subtracts off regions others have completed, since these couldn't be shown to the current user.