### PR TITLE
detects contours within another contour (ie if the ROI has a hole in it)

### DIFF
--- a/src/server/cell_labeling_app/util/util.py
+++ b/src/server/cell_labeling_app/util/util.py
@@ -187,7 +187,7 @@ def get_roi_contours_in_region(experiment_id: str, region: JobRegion,
 
         blank = np.zeros((512, 512), dtype='uint8')
         blank[y:y + height, x:x + width] = mask
-        contours, _ = cv2.findContours(blank, cv2.RETR_EXTERNAL,
+        contours, _ = cv2.findContours(blank, cv2.RETR_TREE,
                                        cv2.CHAIN_APPROX_NONE)
         if reshape_contours_to_list:
             contours = [


### PR DESCRIPTION
Only external contours were being returned. This change allows for interior contours to be returned as well.

For mask
![Screen Shot 2022-04-01 at 2 22 08 PM](https://user-images.githubusercontent.com/5454341/161603048-5c2dff2f-7cc8-44b4-ad3c-1f26a6b9b2c1.png)


# Before
![image](https://user-images.githubusercontent.com/5454341/161554150-b4dae911-f9f3-4389-b31f-d33e461ab81b.png)

# After
![Screen Shot 2022-04-04 at 9 28 01 AM](https://user-images.githubusercontent.com/5454341/161554268-c61b3c92-e879-42d2-8b19-a2ce71b21f85.png)

