### PR TITLE
install ui components using disutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import glob
+
 from setuptools import setup, find_packages
 
 requirements = [r.strip() for r in open('requirements.txt').readlines()]
@@ -10,5 +12,7 @@ setup(
       url="https://github.com/AllenInstitute/cell_labeling_app",
       package_dir={"": "src/server"},
       packages=find_packages(where="src/server"),
-      install_requires=requirements
+      install_requires=requirements,
+      # Specify UI dependencies which need to be installed
+      data_files=[('client', glob.glob('src/client/**/*', recursive=True))]
 )

--- a/src/server/cell_labeling_app/main.py
+++ b/src/server/cell_labeling_app/main.py
@@ -100,8 +100,10 @@ class App(argschema.ArgSchemaParser):
                         Path(__file__).parent.parent.parent / 'client')\
                 .resolve()
         else:
+            # sys.prefix points to virtual environment root,
+            # where "client" dir has been installed
             template_dir = (
-                        Path(__file__).parent / 'client').resolve()
+                        Path(sys.prefix) / 'client').resolve()
         static_dir = template_dir
         app = Flask(__name__, static_folder=static_dir,
                     template_folder=str(template_dir))


### PR DESCRIPTION
#60 

Running the app requires both python code as well as UI code (html, javascript, etc). The UI components were not being installed when we do `pip install .`; they had to be manually copied over to the right place. This PR installs the UI components when using `pip install` so that they do not have to be manually copied. 

Tested manually that it works as expected.