### PR TITLE
PSB-224 truncate trace

### DIFF
--- a/src/client/app.js
+++ b/src/client/app.js
@@ -167,7 +167,7 @@ class CellLabelingApp {
             let trace = data['trace'].slice(firstNonZeroIndex);
 
             trace = {
-                x: _.range(firstNonZeroIndex, trace.length),
+                x: _.range(firstNonZeroIndex, data['trace'].length),
                 y: trace
             }
 

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -161,9 +161,14 @@ class CellLabelingApp {
             })
         }).then(async response => await response.json())
         .then(data => {
-            const trace = {
-                x: _.range(data['trace'].length),
-                y: data['trace']
+
+            // Truncating trace since the first n timesteps in the movie might be blank frames
+            const firstNonZeroIndex = _.findIndex(data['trace'].map(x => x !== 0));
+            let trace = data['trace'].slice(firstNonZeroIndex);
+
+            trace = {
+                x: _.range(firstNonZeroIndex, trace.length),
+                y: trace
             }
 
             const layout = {


### PR DESCRIPTION
Truncates the trace in the UI to avoid showing the first few timesteps which might be blank frames.